### PR TITLE
Madninja/more signal handler

### DIFF
--- a/src/ebus.erl
+++ b/src/ebus.erl
@@ -50,10 +50,11 @@
                     | {struct, [value_type()]}
                     | {dict, KeyType::value_type(), ValueType::value_type()}.
 -type object_path() :: string().
+-type interface() :: string() | undefined.
 -type bus() :: pid().
 -type proxy() :: pid().
 -export_type([message/0, message_type/0, signature/0, value_type/0,
-              object_path/0, proxy/0, bus/0]).
+              object_path/0, interface/0, proxy/0, bus/0]).
 
 -type request_name_opts() :: [request_name_opt()].
 -type request_name_opt() :: {replace_existing, boolean()}

--- a/src/ebus_message.erl
+++ b/src/ebus_message.erl
@@ -81,7 +81,7 @@ serial(Msg, Value) ->
 reply_serial(Msg) ->
     ebus_nif:message_get_reply_serial(Msg).
 
--spec interface(ebus:message()) -> string() | undefined.
+-spec interface(ebus:message()) ->ebus:interface().
 interface(Msg) ->
     ebus_nif:message_get_interface(Msg).
 
@@ -117,7 +117,7 @@ to_map(Msg) ->
 infer_signature(Term) ->
     decode_signature(ebus_nif:message_infer_signature(Term)).
 
--spec split_interface_member(string()) -> {string() | undefined, string()}.
+-spec split_interface_member(string()) -> {ebus:interface(), string()}.
 split_interface_member(Member) ->
     case string:split(Member, ".", trailing) of
         [Member] -> {undefined, Member};

--- a/src/ebus_proxy.erl
+++ b/src/ebus_proxy.erl
@@ -153,7 +153,7 @@ handle_call({add_signal_handler, Path, Member, Handler, Info}, _From, State=#sta
         {ok, SignalID, NewState} ->
             {reply, {ok, SignalID}, NewState};
         {error, Error} ->
-            {reply, Error, State}
+            {reply, {error, Error}, State}
     end;
 
 handle_call(bus, _From, State=#state{}) ->
@@ -165,7 +165,7 @@ handle_call(Msg, _From, State=#state{}) ->
 
 
 handle_cast({remove_signal_handler, SignalID, Handler, Info}, State=#state{}) ->
-    {noreply, signal_handler_remove(SignalID, Handler, State, Info)};
+    {noreply, signal_handler_remove(SignalID, Handler, Info, State)};
 
 handle_cast(Msg, State=#state{}) ->
     lager:warning("Unhandled cast ~p", [Msg]),

--- a/test/proxy_SUITE.erl
+++ b/test/proxy_SUITE.erl
@@ -102,14 +102,14 @@ signal_test(Config) ->
     ok = ebus:send(B, Signal),
     %% Make sure we receive both signals
     receive
-        {ebus_signal, SignalID, Msg, signal_info} ->
+        {ebus_signal, signal_info, SignalID, Msg} ->
             ?assertEqual("Signal", ebus_message:member(Msg)),
             ?assertEqual("/", ebus_message:path(Msg))
     after 5000 -> erlang:exit(timeout_signal)
     end,
 
     receive
-        {ebus_signal, SignalID2, _, signal_info_2} -> ok
+        {ebus_signal, signal_info_2, SignalID2, _} -> ok
     after 5000 -> erlang:exit(timeout_signal_2)
     end,
 
@@ -120,14 +120,14 @@ signal_test(Config) ->
     %% Ensure that we don't receive it
     receive
         %% We should not receive this after removing the AddSignalID
-        {ebus_signal, SignalID, _, signal_info} ->
+        {ebus_signal, signal_info, SignalID, _} ->
             ?assert(received_post_remove_signal)
     after 750 -> ok
     end,
 
     %% But that we do receive the seond handler
     receive
-        {ebus_signal, SignalID2, _, signal_info_2} -> ok
+        {ebus_signal, signal_info_2, SignalID2, _} -> ok
     after 5000 -> erlang:exit(timeout_post_remove_signal_2)
     end,
 
@@ -136,7 +136,7 @@ signal_test(Config) ->
     ok = ebus:send(B, Signal),
     %% Ensure that we don't receive the second handler
     receive
-        {ebus_signal, SignalID2, _, signal_info_2} ->
+        {ebus_signal, signal_info_2, SignalID2, _} ->
             ?assert(false, received_post_remove_signal_2)
     after 750 -> ok
     end,

--- a/test/proxy_SUITE.erl
+++ b/test/proxy_SUITE.erl
@@ -70,3 +70,6 @@ call_test(Config) ->
     meck:unload(call_test),
 
     ok.
+
+signal_test(Config) ->
+    B = ?config(bus, Config),

--- a/test/proxy_SUITE.erl
+++ b/test/proxy_SUITE.erl
@@ -5,10 +5,12 @@
 
 -export([all/0, init_per_suite/1, end_per_suite/1,
          init_per_testcase/2, end_per_testcase/2]).
--export([call_test/1]).
+-export([bus_test/1, call_test/1, signal_test/1]).
 
 all() ->
-    [ call_test
+    [ bus_test,
+      call_test,
+      signal_test
     ].
 
 init_per_suite(Config) ->
@@ -29,6 +31,15 @@ end_per_testcase(_, Config) ->
         B -> exit(B, normal)
     end.
 
+bus_test(Config) ->
+    B = ?config(bus, Config),
+    Dest = "com.helium.test",
+    {ok, Proxy} = ebus_proxy:start(B, Dest, []),
+
+    ?assertEqual(B, ebus_proxy:bus(Proxy)),
+
+    ok.
+
 call_test(Config) ->
     B = ?config(bus, Config),
 
@@ -36,7 +47,7 @@ call_test(Config) ->
     Dest = "com.helium.test",
     ?assertEqual(ok, ebus:request_name(B, Dest, [{replace_existing, true}])),
 
-    Path = "/com/helium/test/Object",
+    Path = "/",
     ?assertEqual(ok, ebus:add_match(B, #{path => Path})),
 
     meck:new(call_test, [non_strict]),
@@ -63,6 +74,7 @@ call_test(Config) ->
     {ok, Proxy} = ebus_proxy:start(B, Dest, []),
     Args = ["Hello World"],
     ?assertEqual({ok, Args}, ebus_proxy:call(Proxy, Path, "Echo", [string], Args)),
+    ?assertEqual({ok, [true]}, ebus_proxy:call(Proxy, "True")),
     ?assertEqual({ok, [true]}, ebus_proxy:call(Proxy, Path, "True")),
     ?assertEqual({error, timeout}, ebus_proxy:call(Proxy, Path, "Timeout", [], [], 1000)),
 
@@ -73,3 +85,60 @@ call_test(Config) ->
 
 signal_test(Config) ->
     B = ?config(bus, Config),
+
+    Dest = "com.helium.test",
+    {ok, Proxy} = ebus_proxy:start(B, Dest, []),
+    %% Check that signal handlers expect an interface
+    ?assertEqual({error, no_interface},
+                 ebus_proxy:add_signal_handler(Proxy, "Signal", self(), no_matter)),
+    %% Add a couple of signal handlers
+    {ok, SignalID} = ebus_proxy:add_signal_handler(Proxy, "com.helium.test.Signal",
+                                                   self(), signal_info),
+    %% Register for the same signal again to ensure multiple registrations work
+    {ok, SignalID2} = ebus_proxy:add_signal_handler(Proxy, "com.helium.test.Signal",
+                                                    self(), signal_info_2),
+    {ok, Signal} = ebus_message:new_signal("/", "com.helium.test.Signal"),
+
+    ok = ebus:send(B, Signal),
+    %% Make sure we receive both signals
+    receive
+        {ebus_signal, SignalID, Msg, signal_info} ->
+            ?assertEqual("Signal", ebus_message:member(Msg)),
+            ?assertEqual("/", ebus_message:path(Msg))
+    after 5000 -> erlang:exit(timeout_signal)
+    end,
+
+    receive
+        {ebus_signal, SignalID2, _, signal_info_2} -> ok
+    after 5000 -> erlang:exit(timeout_signal_2)
+    end,
+
+    %% Remove one signal handler
+    ebus_proxy:remove_signal_handler(Proxy, SignalID, self(), signal_info),
+
+    ok = ebus:send(B, Signal),
+    %% Ensure that we don't receive it
+    receive
+        %% We should not receive this after removing the AddSignalID
+        {ebus_signal, SignalID, _, signal_info} ->
+            ?assert(received_post_remove_signal)
+    after 750 -> ok
+    end,
+
+    %% But that we do receive the seond handler
+    receive
+        {ebus_signal, SignalID2, _, signal_info_2} -> ok
+    after 5000 -> erlang:exit(timeout_post_remove_signal_2)
+    end,
+
+    %% Remove the second handler
+    ebus_proxy:remove_signal_handler(Proxy, SignalID2, self(), signal_info_2),
+    ok = ebus:send(B, Signal),
+    %% Ensure that we don't receive the second handler
+    receive
+        {ebus_signal, SignalID2, _, signal_info_2} ->
+            ?assert(false, received_post_remove_signal_2)
+    after 750 -> ok
+    end,
+
+    ok.


### PR DESCRIPTION
This adds support for better signal handler registration and removal. It manages the match rules, filters and pg2 groups for callers that are interested in receiving a dbus signal