### PR TITLE
Update Makefile for FreeBSD dbus locations.

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -25,7 +25,9 @@ ifeq ($(UNAME_SYS), Darwin)
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CFLAGS += -I /usr/local/include/dbus-1.0 -I /usr/local/lib/dbus-1.0/include
 	CXXFLAGS ?= -O3 -finline-functions -Wall
+	LDFLAGS ?= -L /usr/local/lib
 else ifeq ($(UNAME_SYS), Linux)
 	CC ?= gcc
 	MACHINE ?= $(shell $(CC) -dumpmachine)


### PR DESCRIPTION
On a FreeBSD system, dbus will be installed by the ports system, and its general
location will be:

* Header file directory: `/usr/local/include/dbus-1.0/include`
* Object library directory: `/usr/local/lib`

Tested on a FreeBSD 12.1 system with the `devel/dbus` port
(dbus-1.12.20).