### PR TITLE
Support M1 Macs and OTP23+

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -6,8 +6,6 @@ BASEDIR := $(abspath $(CURDIR)/..)
 PROJECT = ebus
 
 ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts/erts-~ts/include/\", [code:root_dir(), erlang:system_info(version)]).")
-ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts\", [code:lib_dir(erl_interface, include)]).")
-ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts\", [code:lib_dir(erl_interface, lib)]).")
 
 C_SRC_DIR = $(CURDIR)
 C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so
@@ -38,10 +36,10 @@ else ifeq ($(UNAME_SYS), Linux)
 	CXXFLAGS ?= -O3 -finline-functions -Wall
 endif
 
-CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
-CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
+CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR)
+CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR)
 
-LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -ldbus-1
+LDLIBS += -ldbus-1
 LDFLAGS += -shared
 
 # Verbosity.

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -16,10 +16,10 @@ C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
 	CFLAGS += $(shell pkg-config --cflags dbus-1)
-	CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall
-	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+	CXXFLAGS ?= -O3 -finline-functions -Wall
+	LDFLAGS ?= -flat_namespace -undefined suppress
 	LDFLAGS += $(shell pkg-config --libs dbus-1)
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc


### PR DESCRIPTION
This PR is a follow on to @ke6jjj's work in #11 adds support for OTP23+ and/or M1 Apple computers by

- removing dependency on `erl_interface` which was removed in OTP23
  - it's not useful for NIFs; we never needed it to begin with
- removing `-arch x86_64` flag when targeting macOS
  - breaks M1 builds; the compiler knows what arch to target
